### PR TITLE
fixed issue with fallback auth when using Windows AD LDAP

### DIFF
--- a/taiga_contrib_ldap_auth/connector.py
+++ b/taiga_contrib_ldap_auth/connector.py
@@ -100,7 +100,7 @@ def login(login: str, password: str) -> tuple:
 
     # stop if no search results
     # TODO: handle multiple matches
-    if len(c.response) == 0:
+    if (len(c.response) == 0) or (c.response[0].get('type') != 'searchResEntry'):
         raise LDAPUserLoginError({"error_message": "LDAP login not found"})
 
     # attempt LDAP bind


### PR DESCRIPTION
when using Windows AD LDAP, the response is not empty. the LDAPUserLoginError exception will not be raised and fallback auth will not work. adding an additional condition to check for a search response instead of just an empty response fixes the issue.